### PR TITLE
Allow http status "204 No Content" in swift authentication 1.0

### DIFF
--- a/src/main/java/ch/iterate/openstack/swift/handler/Authentication10ResponseHandler.java
+++ b/src/main/java/ch/iterate/openstack/swift/handler/Authentication10ResponseHandler.java
@@ -20,7 +20,8 @@ import ch.iterate.openstack.swift.model.Region;
 public class Authentication10ResponseHandler implements ResponseHandler<AuthenticationResponse> {
 
     public AuthenticationResponse handleResponse(final HttpResponse response) throws ClientProtocolException, IOException {
-        if(response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+        if(response.getStatusLine().getStatusCode() == HttpStatus.SC_OK
+           || response.getStatusLine().getStatusCode() == HttpStatus.SC_NO_CONTENT) {
             return new AuthenticationResponse(response, response.getFirstHeader(Constants.X_AUTH_TOKEN).getValue(),
                     Collections.singleton(new Region(null,
                             this.getStorageURL(response), this.getCDNManagementURL(response), true)));

--- a/src/test/java/ch/iterate/openstack/swift/handler/Authentication10ResponseHandlerTest.java
+++ b/src/test/java/ch/iterate/openstack/swift/handler/Authentication10ResponseHandlerTest.java
@@ -32,4 +32,15 @@ public class Authentication10ResponseHandlerTest {
         });
         assertEquals("eaaafd18-0fed-4b3a-81b4-663c99ec1cbb", response.getAuthToken());
     }
+
+    @Test
+    public void testGetTokenNoContent() throws Exception {
+        final AuthenticationResponse response = new Authentication10ResponseHandler().handleResponse(new BasicHttpResponse(new ProtocolVersion("http", 1, 1), 204, "") {
+            @Override
+            public Header getFirstHeader(final String name) {
+                return new BasicHeader("X-Auth-Token", "48ecf2ca-8978-4d48-8783-b98ae811a062");
+            }
+        });
+        assertEquals("48ecf2ca-8978-4d48-8783-b98ae811a062", response.getAuthToken());
+    }
 }


### PR DESCRIPTION
In commit 
[https://github.com/iterate-ch/java-openstack-swift/commit/ae61c33d5fae18b3a1e52cc36923fe3cdf853748#diff-722781ec12e81ebe2eaa0df044bff7e8](url) 
The compare of http status code changed to constants, but code 204 were left out in Authentication10ResponseHandler.java.
In some swift implementation (for example:  ceph's radosgw), a success swauth v1 authentication which returns 204 will be rejected here.

This PR adds back HttpStatus.SC_NO_CONTENT to Authentication10ResponseHandler alongs with its test.